### PR TITLE
Improve PHPUnit assertions

### DIFF
--- a/tests/HeaderAccessControlAllowCredentialsTest.php
+++ b/tests/HeaderAccessControlAllowCredentialsTest.php
@@ -19,21 +19,21 @@ class HeaderAccessControlAllowCredentialsTest extends TestCase
     {
         $header = new HeaderAccessControlAllowCredentials();
 
-        $this->assertEquals('Access-Control-Allow-Credentials', $header->getFieldName());
+        $this->assertSame('Access-Control-Allow-Credentials', $header->getFieldName());
     }
 
     public function testGetFieldValue()
     {
         $header = new HeaderAccessControlAllowCredentials();
 
-        $this->assertEquals('true', $header->getFieldValue());
+        $this->assertSame('true', $header->getFieldValue());
     }
 
     public function testToString()
     {
         $header = new HeaderAccessControlAllowCredentials();
 
-        $this->assertEquals('Access-Control-Allow-Credentials: true', (string) $header);
+        $this->assertSame('Access-Control-Allow-Credentials: true', (string) $header);
     }
 
     public function testIteration()

--- a/tests/HeaderAccessControlAllowHeadersTest.php
+++ b/tests/HeaderAccessControlAllowHeadersTest.php
@@ -35,7 +35,7 @@ class HeaderAccessControlAllowHeadersTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setValue('value-second'));
 
-        $this->assertEquals([
+        $this->assertSame([
             'value-first',
             'value-second',
         ], $header->getValue());
@@ -47,7 +47,7 @@ class HeaderAccessControlAllowHeadersTest extends TestCase
 
         $header->setValue('value-third', 'value-fourth');
 
-        $this->assertEquals([
+        $this->assertSame([
             'value-first',
             'value-second',
             'value-third',
@@ -77,7 +77,7 @@ class HeaderAccessControlAllowHeadersTest extends TestCase
     {
         $header = new HeaderAccessControlAllowHeaders('value');
 
-        $this->assertEquals(['value'], $header->getValue());
+        $this->assertSame(['value'], $header->getValue());
     }
 
     public function testResetValue()
@@ -86,34 +86,34 @@ class HeaderAccessControlAllowHeadersTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->resetValue());
 
-        $this->assertEquals([], $header->getValue());
+        $this->assertSame([], $header->getValue());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderAccessControlAllowHeaders('value');
 
-        $this->assertEquals('Access-Control-Allow-Headers', $header->getFieldName());
+        $this->assertSame('Access-Control-Allow-Headers', $header->getFieldName());
     }
 
     public function testGetFieldValue()
     {
         $header = new HeaderAccessControlAllowHeaders('value');
 
-        $this->assertEquals('value', $header->getFieldValue());
+        $this->assertSame('value', $header->getFieldValue());
     }
 
     public function testToStringWithOneValue()
     {
         $header = new HeaderAccessControlAllowHeaders('value');
 
-        $this->assertEquals('Access-Control-Allow-Headers: value', (string) $header);
+        $this->assertSame('Access-Control-Allow-Headers: value', (string) $header);
     }
 
     public function testToStringWithSeveralValues()
     {
         $header = new HeaderAccessControlAllowHeaders('value-first', 'value-second', 'value-third');
 
-        $this->assertEquals('Access-Control-Allow-Headers: value-first, value-second, value-third', (string) $header);
+        $this->assertSame('Access-Control-Allow-Headers: value-first, value-second, value-third', (string) $header);
     }
 }

--- a/tests/HeaderAccessControlAllowMethodsTest.php
+++ b/tests/HeaderAccessControlAllowMethodsTest.php
@@ -35,7 +35,7 @@ class HeaderAccessControlAllowMethodsTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setValue('get'));
 
-        $this->assertEquals([
+        $this->assertSame([
             'HEAD',
             'GET',
         ], $header->getValue());
@@ -47,7 +47,7 @@ class HeaderAccessControlAllowMethodsTest extends TestCase
 
         $header->setValue('post', 'patch');
 
-        $this->assertEquals([
+        $this->assertSame([
             'HEAD',
             'GET',
             'POST',
@@ -77,7 +77,7 @@ class HeaderAccessControlAllowMethodsTest extends TestCase
     {
         $header = new HeaderAccessControlAllowMethods('head');
 
-        $this->assertEquals(['HEAD'], $header->getValue());
+        $this->assertSame(['HEAD'], $header->getValue());
     }
 
     public function testResetValue()
@@ -86,34 +86,34 @@ class HeaderAccessControlAllowMethodsTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->resetValue());
 
-        $this->assertEquals([], $header->getValue());
+        $this->assertSame([], $header->getValue());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderAccessControlAllowMethods('head');
 
-        $this->assertEquals('Access-Control-Allow-Methods', $header->getFieldName());
+        $this->assertSame('Access-Control-Allow-Methods', $header->getFieldName());
     }
 
     public function testGetFieldValue()
     {
         $header = new HeaderAccessControlAllowMethods('head');
 
-        $this->assertEquals('HEAD', $header->getFieldValue());
+        $this->assertSame('HEAD', $header->getFieldValue());
     }
 
     public function testToStringWithOneValue()
     {
         $header = new HeaderAccessControlAllowMethods('head');
 
-        $this->assertEquals('Access-Control-Allow-Methods: HEAD', (string) $header);
+        $this->assertSame('Access-Control-Allow-Methods: HEAD', (string) $header);
     }
 
     public function testToStringWithSeveralValues()
     {
         $header = new HeaderAccessControlAllowMethods('head', 'get', 'post');
 
-        $this->assertEquals('Access-Control-Allow-Methods: HEAD, GET, POST', (string) $header);
+        $this->assertSame('Access-Control-Allow-Methods: HEAD, GET, POST', (string) $header);
     }
 }

--- a/tests/HeaderAccessControlAllowOriginTest.php
+++ b/tests/HeaderAccessControlAllowOriginTest.php
@@ -49,7 +49,7 @@ class HeaderAccessControlAllowOriginTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setUri($uri2));
 
-        $this->assertEquals($uri2, $header->getUri());
+        $this->assertSame($uri2, $header->getUri());
     }
 
     public function testSetEmptyUri()
@@ -60,7 +60,7 @@ class HeaderAccessControlAllowOriginTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setUri(null));
 
-        $this->assertEquals(null, $header->getUri());
+        $this->assertNull($header->getUri());
     }
 
     public function testSetInvalidUriThatWithoutScheme()
@@ -87,28 +87,28 @@ class HeaderAccessControlAllowOriginTest extends TestCase
 
         $header = new HeaderAccessControlAllowOrigin($uri);
 
-        $this->assertEquals($uri, $header->getUri());
+        $this->assertSame($uri, $header->getUri());
     }
 
     public function testGetEmptyUri()
     {
         $header = new HeaderAccessControlAllowOrigin(null);
 
-        $this->assertEquals(null, $header->getUri());
+        $this->assertNull($header->getUri());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderAccessControlAllowOrigin(null);
 
-        $this->assertEquals('Access-Control-Allow-Origin', $header->getFieldName());
+        $this->assertSame('Access-Control-Allow-Origin', $header->getFieldName());
     }
 
     public function testGetFieldValueWithoutUri()
     {
         $header = new HeaderAccessControlAllowOrigin(null);
 
-        $this->assertEquals('*', $header->getFieldValue());
+        $this->assertSame('*', $header->getFieldValue());
     }
 
     public function testGetFieldValueWithSchemeAndHost()
@@ -117,7 +117,7 @@ class HeaderAccessControlAllowOriginTest extends TestCase
 
         $header = new HeaderAccessControlAllowOrigin($uri);
 
-        $this->assertEquals('http://localhost', $header->getFieldValue());
+        $this->assertSame('http://localhost', $header->getFieldValue());
     }
 
     public function testGetFieldValueWithSchemeAndHostAndPort()
@@ -126,7 +126,7 @@ class HeaderAccessControlAllowOriginTest extends TestCase
 
         $header = new HeaderAccessControlAllowOrigin($uri);
 
-        $this->assertEquals('http://localhost:3000', $header->getFieldValue());
+        $this->assertSame('http://localhost:3000', $header->getFieldValue());
     }
 
     public function testGetFieldValueWithValidOrigin()
@@ -135,14 +135,14 @@ class HeaderAccessControlAllowOriginTest extends TestCase
 
         $header = new HeaderAccessControlAllowOrigin($uri);
 
-        $this->assertEquals('http://localhost:3000', $header->getFieldValue());
+        $this->assertSame('http://localhost:3000', $header->getFieldValue());
     }
 
     public function testToStringWithoutUri()
     {
         $header = new HeaderAccessControlAllowOrigin(null);
 
-        $this->assertEquals('Access-Control-Allow-Origin: *', (string) $header);
+        $this->assertSame('Access-Control-Allow-Origin: *', (string) $header);
     }
 
     public function testToStringWithSchemeAndHost()
@@ -151,7 +151,7 @@ class HeaderAccessControlAllowOriginTest extends TestCase
 
         $header = new HeaderAccessControlAllowOrigin($uri);
 
-        $this->assertEquals('Access-Control-Allow-Origin: http://localhost', (string) $header);
+        $this->assertSame('Access-Control-Allow-Origin: http://localhost', (string) $header);
     }
 
     public function testToStringWithSchemeAndHostAndPort()
@@ -160,7 +160,7 @@ class HeaderAccessControlAllowOriginTest extends TestCase
 
         $header = new HeaderAccessControlAllowOrigin($uri);
 
-        $this->assertEquals('Access-Control-Allow-Origin: http://localhost:3000', (string) $header);
+        $this->assertSame('Access-Control-Allow-Origin: http://localhost:3000', (string) $header);
     }
 
     public function testToStringWithValidOrigin()
@@ -169,6 +169,6 @@ class HeaderAccessControlAllowOriginTest extends TestCase
 
         $header = new HeaderAccessControlAllowOrigin($uri);
 
-        $this->assertEquals('Access-Control-Allow-Origin: http://localhost:3000', (string) $header);
+        $this->assertSame('Access-Control-Allow-Origin: http://localhost:3000', (string) $header);
     }
 }

--- a/tests/HeaderAccessControlExposeHeadersTest.php
+++ b/tests/HeaderAccessControlExposeHeadersTest.php
@@ -35,7 +35,7 @@ class HeaderAccessControlExposeHeadersTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setValue('value-second'));
 
-        $this->assertEquals([
+        $this->assertSame([
             'value-first',
             'value-second',
         ], $header->getValue());
@@ -47,7 +47,7 @@ class HeaderAccessControlExposeHeadersTest extends TestCase
 
         $header->setValue('value-third', 'value-fourth');
 
-        $this->assertEquals([
+        $this->assertSame([
             'value-first',
             'value-second',
             'value-third',
@@ -77,7 +77,7 @@ class HeaderAccessControlExposeHeadersTest extends TestCase
     {
         $header = new HeaderAccessControlExposeHeaders('value');
 
-        $this->assertEquals(['value'], $header->getValue());
+        $this->assertSame(['value'], $header->getValue());
     }
 
     public function testResetValue()
@@ -86,34 +86,34 @@ class HeaderAccessControlExposeHeadersTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->resetValue());
 
-        $this->assertEquals([], $header->getValue());
+        $this->assertSame([], $header->getValue());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderAccessControlExposeHeaders('value');
 
-        $this->assertEquals('Access-Control-Expose-Headers', $header->getFieldName());
+        $this->assertSame('Access-Control-Expose-Headers', $header->getFieldName());
     }
 
     public function testGetFieldValue()
     {
         $header = new HeaderAccessControlExposeHeaders('value');
 
-        $this->assertEquals('value', $header->getFieldValue());
+        $this->assertSame('value', $header->getFieldValue());
     }
 
     public function testToStringWithOneValue()
     {
         $header = new HeaderAccessControlExposeHeaders('value');
 
-        $this->assertEquals('Access-Control-Expose-Headers: value', (string) $header);
+        $this->assertSame('Access-Control-Expose-Headers: value', (string) $header);
     }
 
     public function testToStringWithSeveralValues()
     {
         $header = new HeaderAccessControlExposeHeaders('value-first', 'value-second', 'value-third');
 
-        $this->assertEquals('Access-Control-Expose-Headers: value-first, value-second, value-third', (string) $header);
+        $this->assertSame('Access-Control-Expose-Headers: value-first, value-second, value-third', (string) $header);
     }
 }

--- a/tests/HeaderAccessControlMaxAgeTest.php
+++ b/tests/HeaderAccessControlMaxAgeTest.php
@@ -28,7 +28,7 @@ class HeaderAccessControlMaxAgeTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setValue(-1));
 
-        $this->assertEquals(-1, $header->getValue());
+        $this->assertSame(-1, $header->getValue());
     }
 
     public function testSetInvalidValue()
@@ -44,27 +44,27 @@ class HeaderAccessControlMaxAgeTest extends TestCase
     {
         $header = new HeaderAccessControlMaxAge(86400);
 
-        $this->assertEquals(86400, $header->getValue());
+        $this->assertSame(86400, $header->getValue());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderAccessControlMaxAge(86400);
 
-        $this->assertEquals('Access-Control-Max-Age', $header->getFieldName());
+        $this->assertSame('Access-Control-Max-Age', $header->getFieldName());
     }
 
     public function testGetFieldValue()
     {
         $header = new HeaderAccessControlMaxAge(86400);
 
-        $this->assertEquals('86400', $header->getFieldValue());
+        $this->assertSame('86400', $header->getFieldValue());
     }
 
     public function testToString()
     {
         $header = new HeaderAccessControlMaxAge(86400);
 
-        $this->assertEquals('Access-Control-Max-Age: 86400', (string) $header);
+        $this->assertSame('Access-Control-Max-Age: 86400', (string) $header);
     }
 }

--- a/tests/HeaderAgeTest.php
+++ b/tests/HeaderAgeTest.php
@@ -28,7 +28,7 @@ class HeaderAgeTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setValue(1));
 
-        $this->assertEquals(1, $header->getValue());
+        $this->assertSame(1, $header->getValue());
     }
 
     public function testSetInvalidValue()
@@ -44,27 +44,27 @@ class HeaderAgeTest extends TestCase
     {
         $header = new HeaderAge(0);
 
-        $this->assertEquals(0, $header->getValue());
+        $this->assertSame(0, $header->getValue());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderAge(0);
 
-        $this->assertEquals('Age', $header->getFieldName());
+        $this->assertSame('Age', $header->getFieldName());
     }
 
     public function testGetFieldValue()
     {
         $header = new HeaderAge(0);
 
-        $this->assertEquals('0', $header->getFieldValue());
+        $this->assertSame('0', $header->getFieldValue());
     }
 
     public function testToString()
     {
         $header = new HeaderAge(0);
 
-        $this->assertEquals('Age: 0', (string) $header);
+        $this->assertSame('Age: 0', (string) $header);
     }
 }

--- a/tests/HeaderAllowTest.php
+++ b/tests/HeaderAllowTest.php
@@ -35,7 +35,7 @@ class HeaderAllowTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setValue('get'));
 
-        $this->assertEquals([
+        $this->assertSame([
             'HEAD',
             'GET',
         ], $header->getValue());
@@ -47,7 +47,7 @@ class HeaderAllowTest extends TestCase
 
         $header->setValue('post', 'patch');
 
-        $this->assertEquals([
+        $this->assertSame([
             'HEAD',
             'GET',
             'POST',
@@ -77,7 +77,7 @@ class HeaderAllowTest extends TestCase
     {
         $header = new HeaderAllow('head');
 
-        $this->assertEquals(['HEAD'], $header->getValue());
+        $this->assertSame(['HEAD'], $header->getValue());
     }
 
     public function testResetValue()
@@ -86,34 +86,34 @@ class HeaderAllowTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->resetValue());
 
-        $this->assertEquals([], $header->getValue());
+        $this->assertSame([], $header->getValue());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderAllow('head');
 
-        $this->assertEquals('Allow', $header->getFieldName());
+        $this->assertSame('Allow', $header->getFieldName());
     }
 
     public function testGetFieldValue()
     {
         $header = new HeaderAllow('head');
 
-        $this->assertEquals('HEAD', $header->getFieldValue());
+        $this->assertSame('HEAD', $header->getFieldValue());
     }
 
     public function testToStringWithOneValue()
     {
         $header = new HeaderAllow('head');
 
-        $this->assertEquals('Allow: HEAD', (string) $header);
+        $this->assertSame('Allow: HEAD', (string) $header);
     }
 
     public function testToStringWithSeveralValues()
     {
         $header = new HeaderAllow('head', 'get', 'post');
 
-        $this->assertEquals('Allow: HEAD, GET, POST', (string) $header);
+        $this->assertSame('Allow: HEAD, GET, POST', (string) $header);
     }
 }

--- a/tests/HeaderCacheControlTest.php
+++ b/tests/HeaderCacheControlTest.php
@@ -35,7 +35,7 @@ class HeaderCacheControlTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setParameter('name', 'overwritten-value'));
 
-        $this->assertEquals(['name' => 'overwritten-value'], $header->getParameters());
+        $this->assertSame(['name' => 'overwritten-value'], $header->getParameters());
     }
 
     public function testSetSeveralParameters()
@@ -45,7 +45,7 @@ class HeaderCacheControlTest extends TestCase
         $header->setParameter('name-1', 'value-1');
         $header->setParameter('name-2', 'value-2');
 
-        $this->assertEquals([
+        $this->assertSame([
             'name-1' => 'value-1',
             'name-2' => 'value-2',
         ], $header->getParameters());
@@ -81,7 +81,7 @@ class HeaderCacheControlTest extends TestCase
             'name-2' => 'overwritten-value-2',
         ]));
 
-        $this->assertEquals([
+        $this->assertSame([
             'name-1' => 'overwritten-value-1',
             'name-2' => 'overwritten-value-2',
         ], $header->getParameters());
@@ -109,7 +109,7 @@ class HeaderCacheControlTest extends TestCase
     {
         $header = new HeaderCacheControl(['name' => 'value']);
 
-        $this->assertEquals(['name' => 'value'], $header->getParameters());
+        $this->assertSame(['name' => 'value'], $header->getParameters());
     }
 
     public function testClearParameters()
@@ -121,56 +121,56 @@ class HeaderCacheControlTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->clearParameters());
 
-        $this->assertEquals([], $header->getParameters());
+        $this->assertSame([], $header->getParameters());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderCacheControl([]);
 
-        $this->assertEquals('Cache-Control', $header->getFieldName());
+        $this->assertSame('Cache-Control', $header->getFieldName());
     }
 
     public function testGetFieldValueWithoutParameterValue()
     {
         $header = new HeaderCacheControl(['name' => '']);
 
-        $this->assertEquals('name', $header->getFieldValue());
+        $this->assertSame('name', $header->getFieldValue());
     }
 
     public function testGetFieldValueWithParameterValueAsToken()
     {
         $header = new HeaderCacheControl(['name' => 'token']);
 
-        $this->assertEquals('name=token', $header->getFieldValue());
+        $this->assertSame('name=token', $header->getFieldValue());
     }
 
     public function testGetFieldValueWithParameterValueAsQuotedString()
     {
         $header = new HeaderCacheControl(['name' => 'quoted string']);
 
-        $this->assertEquals('name="quoted string"', $header->getFieldValue());
+        $this->assertSame('name="quoted string"', $header->getFieldValue());
     }
 
     public function testToStringWithoutParameterValue()
     {
         $header = new HeaderCacheControl(['name' => '']);
 
-        $this->assertEquals('Cache-Control: name', (string) $header);
+        $this->assertSame('Cache-Control: name', (string) $header);
     }
 
     public function testToStringWithParameterValueAsToken()
     {
         $header = new HeaderCacheControl(['name' => 'token']);
 
-        $this->assertEquals('Cache-Control: name=token', (string) $header);
+        $this->assertSame('Cache-Control: name=token', (string) $header);
     }
 
     public function testToStringWithParameterValueAsQuotedString()
     {
         $header = new HeaderCacheControl(['name' => 'quoted string']);
 
-        $this->assertEquals('Cache-Control: name="quoted string"', (string) $header);
+        $this->assertSame('Cache-Control: name="quoted string"', (string) $header);
     }
 
     public function testToStringWithSeveralParameters()
@@ -181,6 +181,6 @@ class HeaderCacheControlTest extends TestCase
             'name-3' => 'quoted string',
         ]);
 
-        $this->assertEquals('Cache-Control: name-1, name-2=token, name-3="quoted string"', (string) $header);
+        $this->assertSame('Cache-Control: name-1, name-2=token, name-3="quoted string"', (string) $header);
     }
 }

--- a/tests/HeaderClearSiteDataTest.php
+++ b/tests/HeaderClearSiteDataTest.php
@@ -28,7 +28,7 @@ class HeaderClearSiteDataTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setValue('value-second'));
 
-        $this->assertEquals([
+        $this->assertSame([
             'value-first',
             'value-second',
         ], $header->getValue());
@@ -40,7 +40,7 @@ class HeaderClearSiteDataTest extends TestCase
 
         $header->setValue('value-third', 'value-fourth');
 
-        $this->assertEquals([
+        $this->assertSame([
             'value-first',
             'value-second',
             'value-third',
@@ -61,7 +61,7 @@ class HeaderClearSiteDataTest extends TestCase
     {
         $header = new HeaderClearSiteData('value');
 
-        $this->assertEquals(['value'], $header->getValue());
+        $this->assertSame(['value'], $header->getValue());
     }
 
     public function testResetValue()
@@ -70,34 +70,34 @@ class HeaderClearSiteDataTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->resetValue());
 
-        $this->assertEquals([], $header->getValue());
+        $this->assertSame([], $header->getValue());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderClearSiteData('value');
 
-        $this->assertEquals('Clear-Site-Data', $header->getFieldName());
+        $this->assertSame('Clear-Site-Data', $header->getFieldName());
     }
 
     public function testGetFieldValue()
     {
         $header = new HeaderClearSiteData('value');
 
-        $this->assertEquals('"value"', $header->getFieldValue());
+        $this->assertSame('"value"', $header->getFieldValue());
     }
 
     public function testToStringWithOneValue()
     {
         $header = new HeaderClearSiteData('value');
 
-        $this->assertEquals('Clear-Site-Data: "value"', (string) $header);
+        $this->assertSame('Clear-Site-Data: "value"', (string) $header);
     }
 
     public function testToStringWithSeveralValues()
     {
         $header = new HeaderClearSiteData('value-first', 'value-second', 'value-third');
 
-        $this->assertEquals('Clear-Site-Data: "value-first", "value-second", "value-third"', (string) $header);
+        $this->assertSame('Clear-Site-Data: "value-first", "value-second", "value-third"', (string) $header);
     }
 }

--- a/tests/HeaderConnectionTest.php
+++ b/tests/HeaderConnectionTest.php
@@ -10,8 +10,8 @@ class HeaderConnectionTest extends TestCase
 {
     public function testConstants()
     {
-        $this->assertEquals('close', HeaderConnection::CONNECTION_CLOSE);
-        $this->assertEquals('keep-alive', HeaderConnection::CONNECTION_KEEP_ALIVE);
+        $this->assertSame('close', HeaderConnection::CONNECTION_CLOSE);
+        $this->assertSame('keep-alive', HeaderConnection::CONNECTION_KEEP_ALIVE);
     }
 
     public function testConstructor()
@@ -34,7 +34,7 @@ class HeaderConnectionTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setValue('new-value'));
 
-        $this->assertEquals('new-value', $header->getValue());
+        $this->assertSame('new-value', $header->getValue());
     }
 
     public function testSetInvalidValue()
@@ -50,27 +50,27 @@ class HeaderConnectionTest extends TestCase
     {
         $header = new HeaderConnection('value');
 
-        $this->assertEquals('value', $header->getValue());
+        $this->assertSame('value', $header->getValue());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderConnection('value');
 
-        $this->assertEquals('Connection', $header->getFieldName());
+        $this->assertSame('Connection', $header->getFieldName());
     }
 
     public function testGetFieldValue()
     {
         $header = new HeaderConnection('value');
 
-        $this->assertEquals('value', $header->getFieldValue());
+        $this->assertSame('value', $header->getFieldValue());
     }
 
     public function testToString()
     {
         $header = new HeaderConnection('value');
 
-        $this->assertEquals('Connection: value', (string) $header);
+        $this->assertSame('Connection: value', (string) $header);
     }
 }

--- a/tests/HeaderContentDispositionTest.php
+++ b/tests/HeaderContentDispositionTest.php
@@ -42,7 +42,7 @@ class HeaderContentDispositionTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setType('overwritten-type'));
 
-        $this->assertEquals('overwritten-type', $header->getType());
+        $this->assertSame('overwritten-type', $header->getType());
     }
 
     public function testSetInvalidType()
@@ -63,7 +63,7 @@ class HeaderContentDispositionTest extends TestCase
             $header->setParameter('parameter-name', 'overwritten-parameter-value')
         );
 
-        $this->assertEquals(['parameter-name' => 'overwritten-parameter-value'], $header->getParameters());
+        $this->assertSame(['parameter-name' => 'overwritten-parameter-value'], $header->getParameters());
     }
 
     public function testSetSeveralParameters()
@@ -76,7 +76,7 @@ class HeaderContentDispositionTest extends TestCase
         $header->setParameter('parameter-name-1', 'overwritten-parameter-value-1');
         $header->setParameter('parameter-name-2', 'overwritten-parameter-value-2');
 
-        $this->assertEquals([
+        $this->assertSame([
             'parameter-name-1' => 'overwritten-parameter-value-1',
             'parameter-name-2' => 'overwritten-parameter-value-2',
         ], $header->getParameters());
@@ -112,7 +112,7 @@ class HeaderContentDispositionTest extends TestCase
             'parameter-name-2' => 'overwritten-parameter-value-2',
         ]));
 
-        $this->assertEquals([
+        $this->assertSame([
             'parameter-name-1' => 'overwritten-parameter-value-1',
             'parameter-name-2' => 'overwritten-parameter-value-2',
         ], $header->getParameters());
@@ -140,14 +140,14 @@ class HeaderContentDispositionTest extends TestCase
     {
         $header = new HeaderContentDisposition('type');
 
-        $this->assertEquals('type', $header->getType());
+        $this->assertSame('type', $header->getType());
     }
 
     public function testGetParameters()
     {
         $header = new HeaderContentDisposition('type', ['parameter-name' => 'parameter-value']);
 
-        $this->assertEquals(['parameter-name' => 'parameter-value'], $header->getParameters());
+        $this->assertSame(['parameter-name' => 'parameter-value'], $header->getParameters());
     }
 
     public function testClearParameters()
@@ -164,42 +164,42 @@ class HeaderContentDispositionTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->clearParameters());
 
-        $this->assertEquals([], $header->getParameters());
+        $this->assertSame([], $header->getParameters());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderContentDisposition('type');
 
-        $this->assertEquals('Content-Disposition', $header->getFieldName());
+        $this->assertSame('Content-Disposition', $header->getFieldName());
     }
 
     public function testGetFieldValue()
     {
         $header = new HeaderContentDisposition('type', ['parameter-name' => 'parameter-value']);
 
-        $this->assertEquals('type; parameter-name="parameter-value"', $header->getFieldValue());
+        $this->assertSame('type; parameter-name="parameter-value"', $header->getFieldValue());
     }
 
     public function testToStringWithoutParameters()
     {
         $header = new HeaderContentDisposition('type');
 
-        $this->assertEquals('Content-Disposition: type', (string) $header);
+        $this->assertSame('Content-Disposition: type', (string) $header);
     }
 
     public function testToStringWithParameterWithoutValue()
     {
         $header = new HeaderContentDisposition('type', ['parameter-name' => '']);
 
-        $this->assertEquals('Content-Disposition: type; parameter-name=""', (string) $header);
+        $this->assertSame('Content-Disposition: type; parameter-name=""', (string) $header);
     }
 
     public function testToStringWithOneParameter()
     {
         $header = new HeaderContentDisposition('type', ['parameter-name' => 'parameter-value']);
 
-        $this->assertEquals('Content-Disposition: type; parameter-name="parameter-value"', (string) $header);
+        $this->assertSame('Content-Disposition: type; parameter-name="parameter-value"', (string) $header);
     }
 
     public function testToStringWithSeveralParameters()
@@ -213,6 +213,6 @@ class HeaderContentDispositionTest extends TestCase
         $expected = 'Content-Disposition: type; parameter-name-1="parameter-value-1"; ' .
                     'parameter-name-2="parameter-value-2"; parameter-name-3="parameter-value-3"';
 
-        $this->assertEquals($expected, (string) $header);
+        $this->assertSame($expected, (string) $header);
     }
 }

--- a/tests/HeaderContentEncodingTest.php
+++ b/tests/HeaderContentEncodingTest.php
@@ -28,7 +28,7 @@ class HeaderContentEncodingTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setValue('new-value'));
 
-        $this->assertEquals('new-value', $header->getValue());
+        $this->assertSame('new-value', $header->getValue());
     }
 
     public function testSetInvalidValue()
@@ -44,27 +44,27 @@ class HeaderContentEncodingTest extends TestCase
     {
         $header = new HeaderContentEncoding('value');
 
-        $this->assertEquals('value', $header->getValue());
+        $this->assertSame('value', $header->getValue());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderContentEncoding('value');
 
-        $this->assertEquals('Content-Encoding', $header->getFieldName());
+        $this->assertSame('Content-Encoding', $header->getFieldName());
     }
 
     public function testGetFieldValue()
     {
         $header = new HeaderContentEncoding('value');
 
-        $this->assertEquals('value', $header->getFieldValue());
+        $this->assertSame('value', $header->getFieldValue());
     }
 
     public function testToString()
     {
         $header = new HeaderContentEncoding('value');
 
-        $this->assertEquals('Content-Encoding: value', (string) $header);
+        $this->assertSame('Content-Encoding: value', (string) $header);
     }
 }

--- a/tests/HeaderContentLanguageTest.php
+++ b/tests/HeaderContentLanguageTest.php
@@ -42,7 +42,7 @@ class HeaderContentLanguageTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setValue('value-second'));
 
-        $this->assertEquals([
+        $this->assertSame([
             'value-first',
             'value-second',
         ], $header->getValue());
@@ -54,7 +54,7 @@ class HeaderContentLanguageTest extends TestCase
 
         $header->setValue('value-third', 'value-fourth');
 
-        $this->assertEquals([
+        $this->assertSame([
             'value-first',
             'value-second',
             'value-third',
@@ -93,7 +93,7 @@ class HeaderContentLanguageTest extends TestCase
     {
         $header = new HeaderContentLanguage('value');
 
-        $this->assertEquals(['value'], $header->getValue());
+        $this->assertSame(['value'], $header->getValue());
     }
 
     public function testResetValue()
@@ -102,34 +102,34 @@ class HeaderContentLanguageTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->resetValue());
 
-        $this->assertEquals([], $header->getValue());
+        $this->assertSame([], $header->getValue());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderContentLanguage('value');
 
-        $this->assertEquals('Content-Language', $header->getFieldName());
+        $this->assertSame('Content-Language', $header->getFieldName());
     }
 
     public function testGetFieldValue()
     {
         $header = new HeaderContentLanguage('value');
 
-        $this->assertEquals('value', $header->getFieldValue());
+        $this->assertSame('value', $header->getFieldValue());
     }
 
     public function testToStringWithOneValue()
     {
         $header = new HeaderContentLanguage('value');
 
-        $this->assertEquals('Content-Language: value', (string) $header);
+        $this->assertSame('Content-Language: value', (string) $header);
     }
 
     public function testToStringWithSeveralValues()
     {
         $header = new HeaderContentLanguage('value-first', 'value-second', 'value-third');
 
-        $this->assertEquals('Content-Language: value-first, value-second, value-third', (string) $header);
+        $this->assertSame('Content-Language: value-first, value-second, value-third', (string) $header);
     }
 }

--- a/tests/HeaderContentLengthTest.php
+++ b/tests/HeaderContentLengthTest.php
@@ -28,7 +28,7 @@ class HeaderContentLengthTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setValue(1));
 
-        $this->assertEquals(1, $header->getValue());
+        $this->assertSame(1, $header->getValue());
     }
 
     public function testSetInvalidLength()
@@ -44,27 +44,27 @@ class HeaderContentLengthTest extends TestCase
     {
         $header = new HeaderContentLength(0);
 
-        $this->assertEquals(0, $header->getValue());
+        $this->assertSame(0, $header->getValue());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderContentLength(0);
 
-        $this->assertEquals('Content-Length', $header->getFieldName());
+        $this->assertSame('Content-Length', $header->getFieldName());
     }
 
     public function testGetFieldValue()
     {
         $header = new HeaderContentLength(0);
 
-        $this->assertEquals('0', $header->getFieldValue());
+        $this->assertSame('0', $header->getFieldValue());
     }
 
     public function testToString()
     {
         $header = new HeaderContentLength(0);
 
-        $this->assertEquals('Content-Length: 0', (string) $header);
+        $this->assertSame('Content-Length: 0', (string) $header);
     }
 }

--- a/tests/HeaderContentLocationTest.php
+++ b/tests/HeaderContentLocationTest.php
@@ -28,7 +28,7 @@ class HeaderContentLocationTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setUri($news));
 
-        $this->assertEquals($news, $header->getUri());
+        $this->assertSame($news, $header->getUri());
     }
 
     public function testGetUri()
@@ -37,7 +37,7 @@ class HeaderContentLocationTest extends TestCase
 
         $header = new HeaderContentLocation($home);
 
-        $this->assertEquals($home, $header->getUri());
+        $this->assertSame($home, $header->getUri());
     }
 
     public function testGetFieldName()
@@ -46,7 +46,7 @@ class HeaderContentLocationTest extends TestCase
 
         $header = new HeaderContentLocation($home);
 
-        $this->assertEquals('Content-Location', $header->getFieldName());
+        $this->assertSame('Content-Location', $header->getFieldName());
     }
 
     public function testGetFieldValue()
@@ -55,7 +55,7 @@ class HeaderContentLocationTest extends TestCase
 
         $header = new HeaderContentLocation($home);
 
-        $this->assertEquals('/', $header->getFieldValue());
+        $this->assertSame('/', $header->getFieldValue());
     }
 
     public function testToString()
@@ -64,6 +64,6 @@ class HeaderContentLocationTest extends TestCase
 
         $header = new HeaderContentLocation($home);
 
-        $this->assertEquals('Content-Location: /', (string) $header);
+        $this->assertSame('Content-Location: /', (string) $header);
     }
 }

--- a/tests/HeaderContentMD5Test.php
+++ b/tests/HeaderContentMD5Test.php
@@ -31,7 +31,7 @@ class HeaderContentMD5Test extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setValue(self::TEST_MD5_DIGEST_2));
 
-        $this->assertEquals(self::TEST_MD5_DIGEST_2, $header->getValue());
+        $this->assertSame(self::TEST_MD5_DIGEST_2, $header->getValue());
     }
 
     public function testSetInvalidValue()
@@ -47,27 +47,27 @@ class HeaderContentMD5Test extends TestCase
     {
         $header = new HeaderContentMD5(self::TEST_MD5_DIGEST_1);
 
-        $this->assertEquals(self::TEST_MD5_DIGEST_1, $header->getValue());
+        $this->assertSame(self::TEST_MD5_DIGEST_1, $header->getValue());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderContentMD5(self::TEST_MD5_DIGEST_1);
 
-        $this->assertEquals('Content-MD5', $header->getFieldName());
+        $this->assertSame('Content-MD5', $header->getFieldName());
     }
 
     public function testGetFieldValue()
     {
         $header = new HeaderContentMD5(self::TEST_MD5_DIGEST_1);
 
-        $this->assertEquals(self::TEST_MD5_DIGEST_1, $header->getFieldValue());
+        $this->assertSame(self::TEST_MD5_DIGEST_1, $header->getFieldValue());
     }
 
     public function testToString()
     {
         $header = new HeaderContentMD5(self::TEST_MD5_DIGEST_1);
 
-        $this->assertEquals('Content-MD5: ' . self::TEST_MD5_DIGEST_1, (string) $header);
+        $this->assertSame('Content-MD5: ' . self::TEST_MD5_DIGEST_1, (string) $header);
     }
 }

--- a/tests/HeaderContentRangeTest.php
+++ b/tests/HeaderContentRangeTest.php
@@ -42,52 +42,52 @@ class HeaderContentRangeTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setRange(3, 4, 5));
 
-        $this->assertEquals(3, $header->getFirstBytePosition());
+        $this->assertSame(3, $header->getFirstBytePosition());
 
-        $this->assertEquals(4, $header->getLastBytePosition());
+        $this->assertSame(4, $header->getLastBytePosition());
 
-        $this->assertEquals(5, $header->getInstanceLength());
+        $this->assertSame(5, $header->getInstanceLength());
     }
 
     public function testGetFirstBytePosition()
     {
         $header = new HeaderContentRange(0, 1, 2);
 
-        $this->assertEquals(0, $header->getFirstBytePosition());
+        $this->assertSame(0, $header->getFirstBytePosition());
     }
 
     public function testGetLastBytePosition()
     {
         $header = new HeaderContentRange(0, 1, 2);
 
-        $this->assertEquals(1, $header->getLastBytePosition());
+        $this->assertSame(1, $header->getLastBytePosition());
     }
 
     public function testGetInstanceLength()
     {
         $header = new HeaderContentRange(0, 1, 2);
 
-        $this->assertEquals(2, $header->getInstanceLength());
+        $this->assertSame(2, $header->getInstanceLength());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderContentRange(0, 1, 2);
 
-        $this->assertEquals('Content-Range', $header->getFieldName());
+        $this->assertSame('Content-Range', $header->getFieldName());
     }
 
     public function testGetFieldValue()
     {
         $header = new HeaderContentRange(0, 1, 2);
 
-        $this->assertEquals('bytes 0-1/2', $header->getFieldValue());
+        $this->assertSame('bytes 0-1/2', $header->getFieldValue());
     }
 
     public function testToString()
     {
         $header = new HeaderContentRange(0, 1, 2);
 
-        $this->assertEquals('Content-Range: bytes 0-1/2', (string) $header);
+        $this->assertSame('Content-Range: bytes 0-1/2', (string) $header);
     }
 }

--- a/tests/HeaderContentSecurityPolicyReportOnlyTest.php
+++ b/tests/HeaderContentSecurityPolicyReportOnlyTest.php
@@ -35,7 +35,7 @@ class HeaderContentSecurityPolicyReportOnlyTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setParameter('name', 'overwritten-value'));
 
-        $this->assertEquals(['name' => 'overwritten-value'], $header->getParameters());
+        $this->assertSame(['name' => 'overwritten-value'], $header->getParameters());
     }
 
     public function testSetSeveralParameters()
@@ -45,7 +45,7 @@ class HeaderContentSecurityPolicyReportOnlyTest extends TestCase
         $header->setParameter('name-1', 'value-1');
         $header->setParameter('name-2', 'value-2');
 
-        $this->assertEquals([
+        $this->assertSame([
             'name-1' => 'value-1',
             'name-2' => 'value-2',
         ], $header->getParameters());
@@ -81,7 +81,7 @@ class HeaderContentSecurityPolicyReportOnlyTest extends TestCase
             'name-2' => 'overwritten-value-2',
         ]));
 
-        $this->assertEquals([
+        $this->assertSame([
             'name-1' => 'overwritten-value-1',
             'name-2' => 'overwritten-value-2',
         ], $header->getParameters());
@@ -109,7 +109,7 @@ class HeaderContentSecurityPolicyReportOnlyTest extends TestCase
     {
         $header = new HeaderContentSecurityPolicyReportOnly(['name' => 'value']);
 
-        $this->assertEquals(['name' => 'value'], $header->getParameters());
+        $this->assertSame(['name' => 'value'], $header->getParameters());
     }
 
     public function testClearParameters()
@@ -121,42 +121,42 @@ class HeaderContentSecurityPolicyReportOnlyTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->clearParameters());
 
-        $this->assertEquals([], $header->getParameters());
+        $this->assertSame([], $header->getParameters());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderContentSecurityPolicyReportOnly([]);
 
-        $this->assertEquals('Content-Security-Policy-Report-Only', $header->getFieldName());
+        $this->assertSame('Content-Security-Policy-Report-Only', $header->getFieldName());
     }
 
     public function testGetFieldValueWithoutParameterValue()
     {
         $header = new HeaderContentSecurityPolicyReportOnly(['name' => '']);
 
-        $this->assertEquals('name', $header->getFieldValue());
+        $this->assertSame('name', $header->getFieldValue());
     }
 
     public function testGetFieldValueWithParameterValue()
     {
         $header = new HeaderContentSecurityPolicyReportOnly(['name' => 'value']);
 
-        $this->assertEquals('name value', $header->getFieldValue());
+        $this->assertSame('name value', $header->getFieldValue());
     }
 
     public function testToStringWithoutParameterValue()
     {
         $header = new HeaderContentSecurityPolicyReportOnly(['name' => '']);
 
-        $this->assertEquals('Content-Security-Policy-Report-Only: name', (string) $header);
+        $this->assertSame('Content-Security-Policy-Report-Only: name', (string) $header);
     }
 
     public function testToStringWithParameterValue()
     {
         $header = new HeaderContentSecurityPolicyReportOnly(['name' => 'value']);
 
-        $this->assertEquals('Content-Security-Policy-Report-Only: name value', (string) $header);
+        $this->assertSame('Content-Security-Policy-Report-Only: name value', (string) $header);
     }
 
     public function testToStringWithSeveralParameters()
@@ -169,6 +169,6 @@ class HeaderContentSecurityPolicyReportOnlyTest extends TestCase
 
         $expected = 'Content-Security-Policy-Report-Only: name-1; name-2 value-2; name-3 value-3';
 
-        $this->assertEquals($expected, (string) $header);
+        $this->assertSame($expected, (string) $header);
     }
 }

--- a/tests/HeaderContentSecurityPolicyTest.php
+++ b/tests/HeaderContentSecurityPolicyTest.php
@@ -35,7 +35,7 @@ class HeaderContentSecurityPolicyTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setParameter('name', 'overwritten-value'));
 
-        $this->assertEquals(['name' => 'overwritten-value'], $header->getParameters());
+        $this->assertSame(['name' => 'overwritten-value'], $header->getParameters());
     }
 
     public function testSetSeveralParameters()
@@ -45,7 +45,7 @@ class HeaderContentSecurityPolicyTest extends TestCase
         $header->setParameter('name-1', 'value-1');
         $header->setParameter('name-2', 'value-2');
 
-        $this->assertEquals([
+        $this->assertSame([
             'name-1' => 'value-1',
             'name-2' => 'value-2',
         ], $header->getParameters());
@@ -81,7 +81,7 @@ class HeaderContentSecurityPolicyTest extends TestCase
             'name-2' => 'overwritten-value-2',
         ]));
 
-        $this->assertEquals([
+        $this->assertSame([
             'name-1' => 'overwritten-value-1',
             'name-2' => 'overwritten-value-2',
         ], $header->getParameters());
@@ -109,7 +109,7 @@ class HeaderContentSecurityPolicyTest extends TestCase
     {
         $header = new HeaderContentSecurityPolicy(['name' => 'value']);
 
-        $this->assertEquals(['name' => 'value'], $header->getParameters());
+        $this->assertSame(['name' => 'value'], $header->getParameters());
     }
 
     public function testClearParameters()
@@ -121,42 +121,42 @@ class HeaderContentSecurityPolicyTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->clearParameters());
 
-        $this->assertEquals([], $header->getParameters());
+        $this->assertSame([], $header->getParameters());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderContentSecurityPolicy([]);
 
-        $this->assertEquals('Content-Security-Policy', $header->getFieldName());
+        $this->assertSame('Content-Security-Policy', $header->getFieldName());
     }
 
     public function testGetFieldValueWithoutParameterValue()
     {
         $header = new HeaderContentSecurityPolicy(['name' => '']);
 
-        $this->assertEquals('name', $header->getFieldValue());
+        $this->assertSame('name', $header->getFieldValue());
     }
 
     public function testGetFieldValueWithParameterValue()
     {
         $header = new HeaderContentSecurityPolicy(['name' => 'value']);
 
-        $this->assertEquals('name value', $header->getFieldValue());
+        $this->assertSame('name value', $header->getFieldValue());
     }
 
     public function testToStringWithoutParameterValue()
     {
         $header = new HeaderContentSecurityPolicy(['name' => '']);
 
-        $this->assertEquals('Content-Security-Policy: name', (string) $header);
+        $this->assertSame('Content-Security-Policy: name', (string) $header);
     }
 
     public function testToStringWithParameterValue()
     {
         $header = new HeaderContentSecurityPolicy(['name' => 'value']);
 
-        $this->assertEquals('Content-Security-Policy: name value', (string) $header);
+        $this->assertSame('Content-Security-Policy: name value', (string) $header);
     }
 
     public function testToStringWithSeveralParameters()
@@ -167,6 +167,6 @@ class HeaderContentSecurityPolicyTest extends TestCase
             'name-3' => 'value-3',
         ]);
 
-        $this->assertEquals('Content-Security-Policy: name-1; name-2 value-2; name-3 value-3', (string) $header);
+        $this->assertSame('Content-Security-Policy: name-1; name-2 value-2; name-3 value-3', (string) $header);
     }
 }

--- a/tests/HeaderContentTypeTest.php
+++ b/tests/HeaderContentTypeTest.php
@@ -42,7 +42,7 @@ class HeaderContentTypeTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setType('overwritten-type'));
 
-        $this->assertEquals('overwritten-type', $header->getType());
+        $this->assertSame('overwritten-type', $header->getType());
     }
 
     public function testSetInvalidType()
@@ -63,7 +63,7 @@ class HeaderContentTypeTest extends TestCase
             $header->setParameter('parameter-name', 'overwritten-parameter-value')
         );
 
-        $this->assertEquals(['parameter-name' => 'overwritten-parameter-value'], $header->getParameters());
+        $this->assertSame(['parameter-name' => 'overwritten-parameter-value'], $header->getParameters());
     }
 
     public function testSetSeveralParameters()
@@ -76,7 +76,7 @@ class HeaderContentTypeTest extends TestCase
         $header->setParameter('parameter-name-1', 'overwritten-parameter-value-1');
         $header->setParameter('parameter-name-2', 'overwritten-parameter-value-2');
 
-        $this->assertEquals([
+        $this->assertSame([
             'parameter-name-1' => 'overwritten-parameter-value-1',
             'parameter-name-2' => 'overwritten-parameter-value-2',
         ], $header->getParameters());
@@ -112,7 +112,7 @@ class HeaderContentTypeTest extends TestCase
             'parameter-name-2' => 'overwritten-parameter-value-2',
         ]));
 
-        $this->assertEquals([
+        $this->assertSame([
             'parameter-name-1' => 'overwritten-parameter-value-1',
             'parameter-name-2' => 'overwritten-parameter-value-2',
         ], $header->getParameters());
@@ -140,14 +140,14 @@ class HeaderContentTypeTest extends TestCase
     {
         $header = new HeaderContentType('type');
 
-        $this->assertEquals('type', $header->getType());
+        $this->assertSame('type', $header->getType());
     }
 
     public function testGetParameters()
     {
         $header = new HeaderContentType('type', ['parameter-name' => 'parameter-value']);
 
-        $this->assertEquals(['parameter-name' => 'parameter-value'], $header->getParameters());
+        $this->assertSame(['parameter-name' => 'parameter-value'], $header->getParameters());
     }
 
     public function testClearParameters()
@@ -164,42 +164,42 @@ class HeaderContentTypeTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->clearParameters());
 
-        $this->assertEquals([], $header->getParameters());
+        $this->assertSame([], $header->getParameters());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderContentType('type');
 
-        $this->assertEquals('Content-Type', $header->getFieldName());
+        $this->assertSame('Content-Type', $header->getFieldName());
     }
 
     public function testGetFieldValue()
     {
         $header = new HeaderContentType('type', ['parameter-name' => 'parameter-value']);
 
-        $this->assertEquals('type; parameter-name="parameter-value"', $header->getFieldValue());
+        $this->assertSame('type; parameter-name="parameter-value"', $header->getFieldValue());
     }
 
     public function testToStringWithoutParameters()
     {
         $header = new HeaderContentType('type');
 
-        $this->assertEquals('Content-Type: type', (string) $header);
+        $this->assertSame('Content-Type: type', (string) $header);
     }
 
     public function testToStringWithParameterWithoutValue()
     {
         $header = new HeaderContentType('type', ['parameter-name' => '']);
 
-        $this->assertEquals('Content-Type: type; parameter-name=""', (string) $header);
+        $this->assertSame('Content-Type: type; parameter-name=""', (string) $header);
     }
 
     public function testToStringWithOneParameter()
     {
         $header = new HeaderContentType('type', ['parameter-name' => 'parameter-value']);
 
-        $this->assertEquals('Content-Type: type; parameter-name="parameter-value"', (string) $header);
+        $this->assertSame('Content-Type: type; parameter-name="parameter-value"', (string) $header);
     }
 
     public function testToStringWithSeveralParameters()
@@ -213,6 +213,6 @@ class HeaderContentTypeTest extends TestCase
         $expected = 'Content-Type: type; parameter-name-1="parameter-value-1"; ' .
                     'parameter-name-2="parameter-value-2"; parameter-name-3="parameter-value-3"';
 
-        $this->assertEquals($expected, (string) $header);
+        $this->assertSame($expected, (string) $header);
     }
 }

--- a/tests/HeaderCookieTest.php
+++ b/tests/HeaderCookieTest.php
@@ -35,7 +35,7 @@ class HeaderCookieTest extends TestCase
     {
         $header = new HeaderCookie();
 
-        $this->assertEquals('Cookie', $header->getFieldName());
+        $this->assertSame('Cookie', $header->getFieldName());
     }
 
     public function testGetFieldValue()
@@ -46,7 +46,7 @@ class HeaderCookieTest extends TestCase
             'baz' => ['qux'],
         ]);
 
-        $this->assertEquals('foo=bar; bar=baz; baz%5B0%5D=qux', $header->getFieldValue());
+        $this->assertSame('foo=bar; bar=baz; baz%5B0%5D=qux', $header->getFieldValue());
     }
 
     public function testToString()
@@ -57,6 +57,6 @@ class HeaderCookieTest extends TestCase
             'baz' => ['qux'],
         ]);
 
-        $this->assertEquals('Cookie: foo=bar; bar=baz; baz%5B0%5D=qux', (string) $header);
+        $this->assertSame('Cookie: foo=bar; bar=baz; baz%5B0%5D=qux', (string) $header);
     }
 }

--- a/tests/HeaderDateTest.php
+++ b/tests/HeaderDateTest.php
@@ -27,7 +27,7 @@ class HeaderDateTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setTimestamp($tomorrow));
 
-        $this->assertEquals($tomorrow, $header->getTimestamp());
+        $this->assertSame($tomorrow, $header->getTimestamp());
     }
 
     public function testGetTimestamp()
@@ -36,7 +36,7 @@ class HeaderDateTest extends TestCase
 
         $header = new HeaderDate($now);
 
-        $this->assertEquals($now, $header->getTimestamp());
+        $this->assertSame($now, $header->getTimestamp());
     }
 
     public function testGetFieldName()
@@ -45,7 +45,7 @@ class HeaderDateTest extends TestCase
 
         $header = new HeaderDate($now);
 
-        $this->assertEquals('Date', $header->getFieldName());
+        $this->assertSame('Date', $header->getFieldName());
     }
 
     public function testGetFieldValue()
@@ -56,7 +56,7 @@ class HeaderDateTest extends TestCase
 
         $expected = new \DateTime('now', new \DateTimeZone('UTC'));
 
-        $this->assertEquals($expected->format(\DateTime::RFC822), $header->getFieldValue());
+        $this->assertSame($expected->format(\DateTime::RFC822), $header->getFieldValue());
     }
 
     public function testToString()
@@ -65,6 +65,6 @@ class HeaderDateTest extends TestCase
 
         $header = new HeaderDate($now);
 
-        $this->assertEquals(\sprintf('Date: %s', $now->format(\DateTime::RFC822)), (string) $header);
+        $this->assertSame(\sprintf('Date: %s', $now->format(\DateTime::RFC822)), (string) $header);
     }
 }

--- a/tests/HeaderEtagTest.php
+++ b/tests/HeaderEtagTest.php
@@ -28,7 +28,7 @@ class HeaderEtagTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setValue('new-value'));
 
-        $this->assertEquals('new-value', $header->getValue());
+        $this->assertSame('new-value', $header->getValue());
     }
 
     public function testSetInvalidValue()
@@ -44,27 +44,27 @@ class HeaderEtagTest extends TestCase
     {
         $header = new HeaderEtag('value');
 
-        $this->assertEquals('value', $header->getValue());
+        $this->assertSame('value', $header->getValue());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderEtag('value');
 
-        $this->assertEquals('ETag', $header->getFieldName());
+        $this->assertSame('ETag', $header->getFieldName());
     }
 
     public function testGetFieldValue()
     {
         $header = new HeaderEtag('value');
 
-        $this->assertEquals('"value"', $header->getFieldValue());
+        $this->assertSame('"value"', $header->getFieldValue());
     }
 
     public function testToString()
     {
         $header = new HeaderEtag('value');
 
-        $this->assertEquals('ETag: "value"', (string) $header);
+        $this->assertSame('ETag: "value"', (string) $header);
     }
 }

--- a/tests/HeaderExpiresTest.php
+++ b/tests/HeaderExpiresTest.php
@@ -27,7 +27,7 @@ class HeaderExpiresTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setTimestamp($tomorrow));
 
-        $this->assertEquals($tomorrow, $header->getTimestamp());
+        $this->assertSame($tomorrow, $header->getTimestamp());
     }
 
     public function testGetTimestamp()
@@ -36,7 +36,7 @@ class HeaderExpiresTest extends TestCase
 
         $header = new HeaderExpires($now);
 
-        $this->assertEquals($now, $header->getTimestamp());
+        $this->assertSame($now, $header->getTimestamp());
     }
 
     public function testGetFieldName()
@@ -45,7 +45,7 @@ class HeaderExpiresTest extends TestCase
 
         $header = new HeaderExpires($now);
 
-        $this->assertEquals('Expires', $header->getFieldName());
+        $this->assertSame('Expires', $header->getFieldName());
     }
 
     public function testGetFieldValue()
@@ -56,7 +56,7 @@ class HeaderExpiresTest extends TestCase
 
         $expected = new \DateTime('now', new \DateTimeZone('UTC'));
 
-        $this->assertEquals($expected->format(\DateTime::RFC822), $header->getFieldValue());
+        $this->assertSame($expected->format(\DateTime::RFC822), $header->getFieldValue());
     }
 
     public function testToString()
@@ -65,6 +65,6 @@ class HeaderExpiresTest extends TestCase
 
         $header = new HeaderExpires($now);
 
-        $this->assertEquals(\sprintf('Expires: %s', $now->format(\DateTime::RFC822)), (string) $header);
+        $this->assertSame(\sprintf('Expires: %s', $now->format(\DateTime::RFC822)), (string) $header);
     }
 }

--- a/tests/HeaderKeepAliveTest.php
+++ b/tests/HeaderKeepAliveTest.php
@@ -35,7 +35,7 @@ class HeaderKeepAliveTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setParameter('name', 'overwritten-value'));
 
-        $this->assertEquals(['name' => 'overwritten-value'], $header->getParameters());
+        $this->assertSame(['name' => 'overwritten-value'], $header->getParameters());
     }
 
     public function testSetSeveralParameters()
@@ -45,7 +45,7 @@ class HeaderKeepAliveTest extends TestCase
         $header->setParameter('name-1', 'value-1');
         $header->setParameter('name-2', 'value-2');
 
-        $this->assertEquals([
+        $this->assertSame([
             'name-1' => 'value-1',
             'name-2' => 'value-2',
         ], $header->getParameters());
@@ -81,7 +81,7 @@ class HeaderKeepAliveTest extends TestCase
             'name-2' => 'overwritten-value-2',
         ]));
 
-        $this->assertEquals([
+        $this->assertSame([
             'name-1' => 'overwritten-value-1',
             'name-2' => 'overwritten-value-2',
         ], $header->getParameters());
@@ -109,7 +109,7 @@ class HeaderKeepAliveTest extends TestCase
     {
         $header = new HeaderKeepAlive(['name' => 'value']);
 
-        $this->assertEquals(['name' => 'value'], $header->getParameters());
+        $this->assertSame(['name' => 'value'], $header->getParameters());
     }
 
     public function testClearParameters()
@@ -121,56 +121,56 @@ class HeaderKeepAliveTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->clearParameters());
 
-        $this->assertEquals([], $header->getParameters());
+        $this->assertSame([], $header->getParameters());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderKeepAlive([]);
 
-        $this->assertEquals('Keep-Alive', $header->getFieldName());
+        $this->assertSame('Keep-Alive', $header->getFieldName());
     }
 
     public function testGetFieldValueWithoutParameterValue()
     {
         $header = new HeaderKeepAlive(['name' => '']);
 
-        $this->assertEquals('name', $header->getFieldValue());
+        $this->assertSame('name', $header->getFieldValue());
     }
 
     public function testGetFieldValueWithParameterValueAsToken()
     {
         $header = new HeaderKeepAlive(['name' => 'token']);
 
-        $this->assertEquals('name=token', $header->getFieldValue());
+        $this->assertSame('name=token', $header->getFieldValue());
     }
 
     public function testGetFieldValueWithParameterValueAsQuotedString()
     {
         $header = new HeaderKeepAlive(['name' => 'quoted string']);
 
-        $this->assertEquals('name="quoted string"', $header->getFieldValue());
+        $this->assertSame('name="quoted string"', $header->getFieldValue());
     }
 
     public function testToStringWithoutParameterValue()
     {
         $header = new HeaderKeepAlive(['name' => '']);
 
-        $this->assertEquals('Keep-Alive: name', (string) $header);
+        $this->assertSame('Keep-Alive: name', (string) $header);
     }
 
     public function testToStringWithParameterValueAsToken()
     {
         $header = new HeaderKeepAlive(['name' => 'token']);
 
-        $this->assertEquals('Keep-Alive: name=token', (string) $header);
+        $this->assertSame('Keep-Alive: name=token', (string) $header);
     }
 
     public function testToStringWithParameterValueAsQuotedString()
     {
         $header = new HeaderKeepAlive(['name' => 'quoted string']);
 
-        $this->assertEquals('Keep-Alive: name="quoted string"', (string) $header);
+        $this->assertSame('Keep-Alive: name="quoted string"', (string) $header);
     }
 
     public function testToStringWithSeveralParameters()
@@ -181,6 +181,6 @@ class HeaderKeepAliveTest extends TestCase
             'name-3' => 'quoted string',
         ]);
 
-        $this->assertEquals('Keep-Alive: name-1, name-2=token, name-3="quoted string"', (string) $header);
+        $this->assertSame('Keep-Alive: name-1, name-2=token, name-3="quoted string"', (string) $header);
     }
 }

--- a/tests/HeaderLastModifiedTest.php
+++ b/tests/HeaderLastModifiedTest.php
@@ -27,7 +27,7 @@ class HeaderLastModifiedTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setTimestamp($tomorrow));
 
-        $this->assertEquals($tomorrow, $header->getTimestamp());
+        $this->assertSame($tomorrow, $header->getTimestamp());
     }
 
     public function testGetTimestamp()
@@ -36,7 +36,7 @@ class HeaderLastModifiedTest extends TestCase
 
         $header = new HeaderLastModified($now);
 
-        $this->assertEquals($now, $header->getTimestamp());
+        $this->assertSame($now, $header->getTimestamp());
     }
 
     public function testGetFieldName()
@@ -45,7 +45,7 @@ class HeaderLastModifiedTest extends TestCase
 
         $header = new HeaderLastModified($now);
 
-        $this->assertEquals('Last-Modified', $header->getFieldName());
+        $this->assertSame('Last-Modified', $header->getFieldName());
     }
 
     public function testGetFieldValue()
@@ -56,7 +56,7 @@ class HeaderLastModifiedTest extends TestCase
 
         $expected = new \DateTime('now', new \DateTimeZone('UTC'));
 
-        $this->assertEquals($expected->format(\DateTime::RFC822), $header->getFieldValue());
+        $this->assertSame($expected->format(\DateTime::RFC822), $header->getFieldValue());
     }
 
     public function testToString()
@@ -65,6 +65,6 @@ class HeaderLastModifiedTest extends TestCase
 
         $header = new HeaderLastModified($now);
 
-        $this->assertEquals(\sprintf('Last-Modified: %s', $now->format(\DateTime::RFC822)), (string) $header);
+        $this->assertSame(\sprintf('Last-Modified: %s', $now->format(\DateTime::RFC822)), (string) $header);
     }
 }

--- a/tests/HeaderLinkTest.php
+++ b/tests/HeaderLinkTest.php
@@ -46,7 +46,7 @@ class HeaderLinkTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setUri($uri2));
 
-        $this->assertEquals($uri2, $header->getUri());
+        $this->assertSame($uri2, $header->getUri());
     }
 
     public function testSetParameter()
@@ -60,7 +60,7 @@ class HeaderLinkTest extends TestCase
             $header->setParameter('parameter-name', 'overwritten-parameter-value')
         );
 
-        $this->assertEquals(['parameter-name' => 'overwritten-parameter-value'], $header->getParameters());
+        $this->assertSame(['parameter-name' => 'overwritten-parameter-value'], $header->getParameters());
     }
 
     public function testSetSeveralParameters()
@@ -75,7 +75,7 @@ class HeaderLinkTest extends TestCase
         $header->setParameter('parameter-name-1', 'overwritten-parameter-value-1');
         $header->setParameter('parameter-name-2', 'overwritten-parameter-value-2');
 
-        $this->assertEquals([
+        $this->assertSame([
             'parameter-name-1' => 'overwritten-parameter-value-1',
             'parameter-name-2' => 'overwritten-parameter-value-2',
         ], $header->getParameters());
@@ -117,7 +117,7 @@ class HeaderLinkTest extends TestCase
             'parameter-name-2' => 'overwritten-parameter-value-2',
         ]));
 
-        $this->assertEquals([
+        $this->assertSame([
             'parameter-name-1' => 'overwritten-parameter-value-1',
             'parameter-name-2' => 'overwritten-parameter-value-2',
         ], $header->getParameters());
@@ -151,7 +151,7 @@ class HeaderLinkTest extends TestCase
 
         $header = new HeaderLink($uri);
 
-        $this->assertEquals($uri, $header->getUri());
+        $this->assertSame($uri, $header->getUri());
     }
 
     public function testGetParameters()
@@ -160,7 +160,7 @@ class HeaderLinkTest extends TestCase
 
         $header = new HeaderLink($uri, ['parameter-name' => 'parameter-value']);
 
-        $this->assertEquals(['parameter-name' => 'parameter-value'], $header->getParameters());
+        $this->assertSame(['parameter-name' => 'parameter-value'], $header->getParameters());
     }
 
     public function testClearParameters()
@@ -179,7 +179,7 @@ class HeaderLinkTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->clearParameters());
 
-        $this->assertEquals([], $header->getParameters());
+        $this->assertSame([], $header->getParameters());
     }
 
     public function testGetFieldName()
@@ -188,7 +188,7 @@ class HeaderLinkTest extends TestCase
 
         $header = new HeaderLink($uri);
 
-        $this->assertEquals('Link', $header->getFieldName());
+        $this->assertSame('Link', $header->getFieldName());
     }
 
     public function testGetFieldValue()
@@ -197,7 +197,7 @@ class HeaderLinkTest extends TestCase
 
         $header = new HeaderLink($uri, ['parameter-name' => 'parameter-value']);
 
-        $this->assertEquals('</>; parameter-name="parameter-value"', $header->getFieldValue());
+        $this->assertSame('</>; parameter-name="parameter-value"', $header->getFieldValue());
     }
 
     public function testToStringWithoutParameters()
@@ -206,7 +206,7 @@ class HeaderLinkTest extends TestCase
 
         $header = new HeaderLink($uri);
 
-        $this->assertEquals('Link: </>', (string) $header);
+        $this->assertSame('Link: </>', (string) $header);
     }
 
     public function testToStringWithParameterWithoutValue()
@@ -215,7 +215,7 @@ class HeaderLinkTest extends TestCase
 
         $header = new HeaderLink($uri, ['parameter-name' => '']);
 
-        $this->assertEquals('Link: </>; parameter-name=""', (string) $header);
+        $this->assertSame('Link: </>; parameter-name=""', (string) $header);
     }
 
     public function testToStringWithOneParameter()
@@ -224,7 +224,7 @@ class HeaderLinkTest extends TestCase
 
         $header = new HeaderLink($uri, ['parameter-name' => 'parameter-value']);
 
-        $this->assertEquals('Link: </>; parameter-name="parameter-value"', (string) $header);
+        $this->assertSame('Link: </>; parameter-name="parameter-value"', (string) $header);
     }
 
     public function testToStringWithSeveralParameters()
@@ -240,6 +240,6 @@ class HeaderLinkTest extends TestCase
         $expected = 'Link: </>; parameter-name-1="parameter-value-1"; '.
                     'parameter-name-2="parameter-value-2"; parameter-name-3="parameter-value-3"';
 
-        $this->assertEquals($expected, (string) $header);
+        $this->assertSame($expected, (string) $header);
     }
 }

--- a/tests/HeaderLocationTest.php
+++ b/tests/HeaderLocationTest.php
@@ -28,7 +28,7 @@ class HeaderLocationTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setUri($news));
 
-        $this->assertEquals($news, $header->getUri());
+        $this->assertSame($news, $header->getUri());
     }
 
     public function testGetUri()
@@ -37,7 +37,7 @@ class HeaderLocationTest extends TestCase
 
         $header = new HeaderLocation($home);
 
-        $this->assertEquals($home, $header->getUri());
+        $this->assertSame($home, $header->getUri());
     }
 
     public function testGetFieldName()
@@ -46,7 +46,7 @@ class HeaderLocationTest extends TestCase
 
         $header = new HeaderLocation($home);
 
-        $this->assertEquals('Location', $header->getFieldName());
+        $this->assertSame('Location', $header->getFieldName());
     }
 
     public function testGetFieldValue()
@@ -55,7 +55,7 @@ class HeaderLocationTest extends TestCase
 
         $header = new HeaderLocation($home);
 
-        $this->assertEquals('/', $header->getFieldValue());
+        $this->assertSame('/', $header->getFieldValue());
     }
 
     public function testToString()
@@ -64,6 +64,6 @@ class HeaderLocationTest extends TestCase
 
         $header = new HeaderLocation($home);
 
-        $this->assertEquals('Location: /', (string) $header);
+        $this->assertSame('Location: /', (string) $header);
     }
 }

--- a/tests/HeaderRefreshTest.php
+++ b/tests/HeaderRefreshTest.php
@@ -35,7 +35,7 @@ class HeaderRefreshTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setDelay(1));
 
-        $this->assertEquals(1, $header->getDelay());
+        $this->assertSame(1, $header->getDelay());
     }
 
     public function testSetInvalidDelay()
@@ -59,7 +59,7 @@ class HeaderRefreshTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setUri($login));
 
-        $this->assertEquals($login, $header->getUri());
+        $this->assertSame($login, $header->getUri());
     }
 
     public function testGetDelay()
@@ -68,7 +68,7 @@ class HeaderRefreshTest extends TestCase
 
         $header = new HeaderRefresh(0, $home);
 
-        $this->assertEquals(0, $header->getDelay());
+        $this->assertSame(0, $header->getDelay());
     }
 
     public function testGetUri()
@@ -77,7 +77,7 @@ class HeaderRefreshTest extends TestCase
 
         $header = new HeaderRefresh(0, $home);
 
-        $this->assertEquals($home, $header->getUri());
+        $this->assertSame($home, $header->getUri());
     }
 
     public function testGetFieldName()
@@ -86,7 +86,7 @@ class HeaderRefreshTest extends TestCase
 
         $header = new HeaderRefresh(0, $home);
 
-        $this->assertEquals('Refresh', $header->getFieldName());
+        $this->assertSame('Refresh', $header->getFieldName());
     }
 
     public function testGetFieldValue()
@@ -95,7 +95,7 @@ class HeaderRefreshTest extends TestCase
 
         $header = new HeaderRefresh(0, $home);
 
-        $this->assertEquals('0; url=/', $header->getFieldValue());
+        $this->assertSame('0; url=/', $header->getFieldValue());
     }
 
     public function testToString()
@@ -104,6 +104,6 @@ class HeaderRefreshTest extends TestCase
 
         $header = new HeaderRefresh(0, $home);
 
-        $this->assertEquals('Refresh: 0; url=/', (string) $header);
+        $this->assertSame('Refresh: 0; url=/', (string) $header);
     }
 }

--- a/tests/HeaderRetryAfterTest.php
+++ b/tests/HeaderRetryAfterTest.php
@@ -27,7 +27,7 @@ class HeaderRetryAfterTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setTimestamp($tomorrow));
 
-        $this->assertEquals($tomorrow, $header->getTimestamp());
+        $this->assertSame($tomorrow, $header->getTimestamp());
     }
 
     public function testGetTimestamp()
@@ -36,7 +36,7 @@ class HeaderRetryAfterTest extends TestCase
 
         $header = new HeaderRetryAfter($now);
 
-        $this->assertEquals($now, $header->getTimestamp());
+        $this->assertSame($now, $header->getTimestamp());
     }
 
     public function testGetFieldName()
@@ -45,7 +45,7 @@ class HeaderRetryAfterTest extends TestCase
 
         $header = new HeaderRetryAfter($now);
 
-        $this->assertEquals('Retry-After', $header->getFieldName());
+        $this->assertSame('Retry-After', $header->getFieldName());
     }
 
     public function testGetFieldValue()
@@ -56,7 +56,7 @@ class HeaderRetryAfterTest extends TestCase
 
         $expected = new \DateTime('now', new \DateTimeZone('UTC'));
 
-        $this->assertEquals($expected->format(\DateTime::RFC822), $header->getFieldValue());
+        $this->assertSame($expected->format(\DateTime::RFC822), $header->getFieldValue());
     }
 
     public function testToString()
@@ -65,6 +65,6 @@ class HeaderRetryAfterTest extends TestCase
 
         $header = new HeaderRetryAfter($now);
 
-        $this->assertEquals(\sprintf('Retry-After: %s', $now->format(\DateTime::RFC822)), (string) $header);
+        $this->assertSame(\sprintf('Retry-After: %s', $now->format(\DateTime::RFC822)), (string) $header);
     }
 }

--- a/tests/HeaderSetCookieTest.php
+++ b/tests/HeaderSetCookieTest.php
@@ -56,7 +56,7 @@ class HeaderSetCookieTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setName('newName'));
 
-        $this->assertEquals('newName', $header->getName());
+        $this->assertSame('newName', $header->getName());
     }
 
     public function testSetEmptyName()
@@ -83,7 +83,7 @@ class HeaderSetCookieTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setValue('newValue'));
 
-        $this->assertEquals('newValue', $header->getValue());
+        $this->assertSame('newValue', $header->getValue());
     }
 
     public function testSetExpires()
@@ -96,7 +96,7 @@ class HeaderSetCookieTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setExpires($tomorrow));
 
-        $this->assertEquals($tomorrow, $header->getExpires());
+        $this->assertSame($tomorrow, $header->getExpires());
     }
 
     public function testResetExpires()
@@ -107,7 +107,7 @@ class HeaderSetCookieTest extends TestCase
 
         $header->setExpires(null);
 
-        $this->assertEquals(null, $header->getExpires());
+        $this->assertNull($header->getExpires());
     }
 
     public function testSetDomain()
@@ -116,7 +116,7 @@ class HeaderSetCookieTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setDomain('new.domain.net'));
 
-        $this->assertEquals('new.domain.net', $header->getDomain());
+        $this->assertSame('new.domain.net', $header->getDomain());
     }
 
     public function testSetInvalidDomain()
@@ -134,7 +134,7 @@ class HeaderSetCookieTest extends TestCase
 
         $header->setDomain(null);
 
-        $this->assertEquals(null, $header->getDomain());
+        $this->assertNull($header->getDomain());
     }
 
     public function testSetPath()
@@ -143,7 +143,7 @@ class HeaderSetCookieTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setPath('/new/path/'));
 
-        $this->assertEquals('/new/path/', $header->getPath());
+        $this->assertSame('/new/path/', $header->getPath());
     }
 
     public function testSetInvalidPath()
@@ -161,7 +161,7 @@ class HeaderSetCookieTest extends TestCase
 
         $header->setPath(null);
 
-        $this->assertEquals(null, $header->getPath());
+        $this->assertNull($header->getPath());
     }
 
     public function testSetSecure()
@@ -170,7 +170,7 @@ class HeaderSetCookieTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setSecure(false));
 
-        $this->assertEquals(false, $header->getSecure());
+        $this->assertFalse($header->getSecure());
     }
 
     public function testResetSecure()
@@ -179,7 +179,7 @@ class HeaderSetCookieTest extends TestCase
 
         $header->setSecure(null);
 
-        $this->assertEquals(null, $header->getSecure());
+        $this->assertNull($header->getSecure());
     }
 
     public function testSetHttpOnly()
@@ -188,7 +188,7 @@ class HeaderSetCookieTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setHttpOnly(false));
 
-        $this->assertEquals(false, $header->getHttpOnly());
+        $this->assertFalse($header->getHttpOnly());
     }
 
     public function testResetHttpOnly()
@@ -197,7 +197,7 @@ class HeaderSetCookieTest extends TestCase
 
         $header->setHttpOnly(null);
 
-        $this->assertEquals(null, $header->getHttpOnly());
+        $this->assertNull($header->getHttpOnly());
     }
 
     public function testSetSameSite()
@@ -206,7 +206,7 @@ class HeaderSetCookieTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setSameSite('strict'));
 
-        $this->assertEquals('strict', $header->getSameSite());
+        $this->assertSame('strict', $header->getSameSite());
     }
 
     public function testSetInvalidSameSite()
@@ -224,21 +224,21 @@ class HeaderSetCookieTest extends TestCase
 
         $header->setSameSite(null);
 
-        $this->assertEquals(null, $header->getSameSite());
+        $this->assertNull($header->getSameSite());
     }
 
     public function testGetName()
     {
         $header = new HeaderSetCookie('name', 'value');
 
-        $this->assertEquals('name', $header->getName());
+        $this->assertSame('name', $header->getName());
     }
 
     public function testGetValue()
     {
         $header = new HeaderSetCookie('name', 'value');
 
-        $this->assertEquals('value', $header->getValue());
+        $this->assertSame('value', $header->getValue());
     }
 
     public function testGetExpires()
@@ -247,49 +247,49 @@ class HeaderSetCookieTest extends TestCase
 
         $header = new HeaderSetCookie('name', 'value', $now);
 
-        $this->assertEquals($now, $header->getExpires());
+        $this->assertSame($now, $header->getExpires());
     }
 
     public function testGetDomain()
     {
         $header = new HeaderSetCookie('name', 'value', null, ['domain' => 'domain.net']);
 
-        $this->assertEquals('domain.net', $header->getDomain());
+        $this->assertSame('domain.net', $header->getDomain());
     }
 
     public function testGetPath()
     {
         $header = new HeaderSetCookie('name', 'value', null, ['path' => '/path/']);
 
-        $this->assertEquals('/path/', $header->getPath());
+        $this->assertSame('/path/', $header->getPath());
     }
 
     public function testGetSecure()
     {
         $header = new HeaderSetCookie('name', 'value', null, ['secure' => true]);
 
-        $this->assertEquals(true, $header->getSecure());
+        $this->assertTrue($header->getSecure());
     }
 
     public function testGetHttpOnly()
     {
         $header = new HeaderSetCookie('name', 'value', null, ['httponly' => true]);
 
-        $this->assertEquals(true, $header->getHttpOnly());
+        $this->assertTrue($header->getHttpOnly());
     }
 
     public function testGetSameSite()
     {
         $header = new HeaderSetCookie('name', 'value', null, ['samesite' => 'lax']);
 
-        $this->assertEquals('lax', $header->getSameSite());
+        $this->assertSame('lax', $header->getSameSite());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderSetCookie('name', 'value');
 
-        $this->assertEquals('Set-Cookie', $header->getFieldName());
+        $this->assertSame('Set-Cookie', $header->getFieldName());
     }
 
     public function testGetFieldValue()
@@ -307,7 +307,7 @@ class HeaderSetCookieTest extends TestCase
         $expected = 'name=value; Expires=' . $now->format(\DateTime::RFC822) .
                     '; Max-Age=0; Domain=domain.net; Path=/path/; SameSite=strict';
 
-        $this->assertEquals($expected, $header->getFieldValue());
+        $this->assertSame($expected, $header->getFieldValue());
     }
 
     public function testToString()
@@ -327,6 +327,6 @@ class HeaderSetCookieTest extends TestCase
         $expected = 'Set-Cookie: name=value; Expires=' . $utc->format(\DateTime::RFC822) .
                     '; Max-Age=30; Domain=domain.net; Path=/path/; Secure; HttpOnly; SameSite=strict';
 
-        $this->assertEquals($expected, (string) $header);
+        $this->assertSame($expected, (string) $header);
     }
 }

--- a/tests/HeaderSunsetTest.php
+++ b/tests/HeaderSunsetTest.php
@@ -27,7 +27,7 @@ class HeaderSunsetTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setTimestamp($tomorrow));
 
-        $this->assertEquals($tomorrow, $header->getTimestamp());
+        $this->assertSame($tomorrow, $header->getTimestamp());
     }
 
     public function testGetTimestamp()
@@ -36,7 +36,7 @@ class HeaderSunsetTest extends TestCase
 
         $header = new HeaderSunset($now);
 
-        $this->assertEquals($now, $header->getTimestamp());
+        $this->assertSame($now, $header->getTimestamp());
     }
 
     public function testGetFieldName()
@@ -45,7 +45,7 @@ class HeaderSunsetTest extends TestCase
 
         $header = new HeaderSunset($now);
 
-        $this->assertEquals('Sunset', $header->getFieldName());
+        $this->assertSame('Sunset', $header->getFieldName());
     }
 
     public function testGetFieldValue()
@@ -56,7 +56,7 @@ class HeaderSunsetTest extends TestCase
 
         $expected = new \DateTime('now', new \DateTimeZone('UTC'));
 
-        $this->assertEquals($expected->format(\DateTime::RFC822), $header->getFieldValue());
+        $this->assertSame($expected->format(\DateTime::RFC822), $header->getFieldValue());
     }
 
     public function testToString()
@@ -65,6 +65,6 @@ class HeaderSunsetTest extends TestCase
 
         $header = new HeaderSunset($now);
 
-        $this->assertEquals(\sprintf('Sunset: %s', $now->format(\DateTime::RFC822)), (string) $header);
+        $this->assertSame(\sprintf('Sunset: %s', $now->format(\DateTime::RFC822)), (string) $header);
     }
 }

--- a/tests/HeaderTrailerTest.php
+++ b/tests/HeaderTrailerTest.php
@@ -28,7 +28,7 @@ class HeaderTrailerTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setValue('new-value'));
 
-        $this->assertEquals('new-value', $header->getValue());
+        $this->assertSame('new-value', $header->getValue());
     }
 
     public function testSetInvalidValue()
@@ -44,27 +44,27 @@ class HeaderTrailerTest extends TestCase
     {
         $header = new HeaderTrailer('value');
 
-        $this->assertEquals('value', $header->getValue());
+        $this->assertSame('value', $header->getValue());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderTrailer('value');
 
-        $this->assertEquals('Trailer', $header->getFieldName());
+        $this->assertSame('Trailer', $header->getFieldName());
     }
 
     public function testGetFieldValue()
     {
         $header = new HeaderTrailer('value');
 
-        $this->assertEquals('value', $header->getFieldValue());
+        $this->assertSame('value', $header->getFieldValue());
     }
 
     public function testToString()
     {
         $header = new HeaderTrailer('value');
 
-        $this->assertEquals('Trailer: value', (string) $header);
+        $this->assertSame('Trailer: value', (string) $header);
     }
 }

--- a/tests/HeaderTransferEncodingTest.php
+++ b/tests/HeaderTransferEncodingTest.php
@@ -35,7 +35,7 @@ class HeaderTransferEncodingTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setValue('value-second'));
 
-        $this->assertEquals([
+        $this->assertSame([
             'value-first',
             'value-second',
         ], $header->getValue());
@@ -47,7 +47,7 @@ class HeaderTransferEncodingTest extends TestCase
 
         $header->setValue('value-third', 'value-fourth');
 
-        $this->assertEquals([
+        $this->assertSame([
             'value-first',
             'value-second',
             'value-third',
@@ -77,7 +77,7 @@ class HeaderTransferEncodingTest extends TestCase
     {
         $header = new HeaderTransferEncoding('value');
 
-        $this->assertEquals(['value'], $header->getValue());
+        $this->assertSame(['value'], $header->getValue());
     }
 
     public function testResetValue()
@@ -86,34 +86,34 @@ class HeaderTransferEncodingTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->resetValue());
 
-        $this->assertEquals([], $header->getValue());
+        $this->assertSame([], $header->getValue());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderTransferEncoding('value');
 
-        $this->assertEquals('Transfer-Encoding', $header->getFieldName());
+        $this->assertSame('Transfer-Encoding', $header->getFieldName());
     }
 
     public function testGetFieldValue()
     {
         $header = new HeaderTransferEncoding('value');
 
-        $this->assertEquals('value', $header->getFieldValue());
+        $this->assertSame('value', $header->getFieldValue());
     }
 
     public function testToStringWithOneValue()
     {
         $header = new HeaderTransferEncoding('value');
 
-        $this->assertEquals('Transfer-Encoding: value', (string) $header);
+        $this->assertSame('Transfer-Encoding: value', (string) $header);
     }
 
     public function testToStringWithSeveralValues()
     {
         $header = new HeaderTransferEncoding('value-first', 'value-second', 'value-third');
 
-        $this->assertEquals('Transfer-Encoding: value-first, value-second, value-third', (string) $header);
+        $this->assertSame('Transfer-Encoding: value-first, value-second, value-third', (string) $header);
     }
 }

--- a/tests/HeaderVaryTest.php
+++ b/tests/HeaderVaryTest.php
@@ -35,7 +35,7 @@ class HeaderVaryTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setValue('value-second'));
 
-        $this->assertEquals([
+        $this->assertSame([
             'value-first',
             'value-second',
         ], $header->getValue());
@@ -47,7 +47,7 @@ class HeaderVaryTest extends TestCase
 
         $header->setValue('value-third', 'value-fourth');
 
-        $this->assertEquals([
+        $this->assertSame([
             'value-first',
             'value-second',
             'value-third',
@@ -77,7 +77,7 @@ class HeaderVaryTest extends TestCase
     {
         $header = new HeaderVary('value');
 
-        $this->assertEquals(['value'], $header->getValue());
+        $this->assertSame(['value'], $header->getValue());
     }
 
     public function testResetValue()
@@ -86,34 +86,34 @@ class HeaderVaryTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->resetValue());
 
-        $this->assertEquals([], $header->getValue());
+        $this->assertSame([], $header->getValue());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderVary('value');
 
-        $this->assertEquals('Vary', $header->getFieldName());
+        $this->assertSame('Vary', $header->getFieldName());
     }
 
     public function testGetFieldValue()
     {
         $header = new HeaderVary('value');
 
-        $this->assertEquals('value', $header->getFieldValue());
+        $this->assertSame('value', $header->getFieldValue());
     }
 
     public function testToStringWithOneValue()
     {
         $header = new HeaderVary('value');
 
-        $this->assertEquals('Vary: value', (string) $header);
+        $this->assertSame('Vary: value', (string) $header);
     }
 
     public function testToStringWithSeveralValues()
     {
         $header = new HeaderVary('value-first', 'value-second', 'value-third');
 
-        $this->assertEquals('Vary: value-first, value-second, value-third', (string) $header);
+        $this->assertSame('Vary: value-first, value-second, value-third', (string) $header);
     }
 }

--- a/tests/HeaderWWWAuthenticateTest.php
+++ b/tests/HeaderWWWAuthenticateTest.php
@@ -10,16 +10,16 @@ class HeaderWWWAuthenticateTest extends TestCase
 {
     public function testConstants()
     {
-        $this->assertEquals('Basic', HeaderWWWAuthenticate::HTTP_AUTHENTICATE_SCHEME_BASIC);
-        $this->assertEquals('Bearer', HeaderWWWAuthenticate::HTTP_AUTHENTICATE_SCHEME_BEARER);
-        $this->assertEquals('Digest', HeaderWWWAuthenticate::HTTP_AUTHENTICATE_SCHEME_DIGEST);
-        $this->assertEquals('HOBA', HeaderWWWAuthenticate::HTTP_AUTHENTICATE_SCHEME_HOBA);
-        $this->assertEquals('Mutual', HeaderWWWAuthenticate::HTTP_AUTHENTICATE_SCHEME_MUTUAL);
-        $this->assertEquals('Negotiate', HeaderWWWAuthenticate::HTTP_AUTHENTICATE_SCHEME_NEGOTIATE);
-        $this->assertEquals('OAuth', HeaderWWWAuthenticate::HTTP_AUTHENTICATE_SCHEME_OAUTH);
-        $this->assertEquals('SCRAM-SHA-1', HeaderWWWAuthenticate::HTTP_AUTHENTICATE_SCHEME_SCRAM_SHA_1);
-        $this->assertEquals('SCRAM-SHA-256', HeaderWWWAuthenticate::HTTP_AUTHENTICATE_SCHEME_SCRAM_SHA_256);
-        $this->assertEquals('vapid', HeaderWWWAuthenticate::HTTP_AUTHENTICATE_SCHEME_VAPID);
+        $this->assertSame('Basic', HeaderWWWAuthenticate::HTTP_AUTHENTICATE_SCHEME_BASIC);
+        $this->assertSame('Bearer', HeaderWWWAuthenticate::HTTP_AUTHENTICATE_SCHEME_BEARER);
+        $this->assertSame('Digest', HeaderWWWAuthenticate::HTTP_AUTHENTICATE_SCHEME_DIGEST);
+        $this->assertSame('HOBA', HeaderWWWAuthenticate::HTTP_AUTHENTICATE_SCHEME_HOBA);
+        $this->assertSame('Mutual', HeaderWWWAuthenticate::HTTP_AUTHENTICATE_SCHEME_MUTUAL);
+        $this->assertSame('Negotiate', HeaderWWWAuthenticate::HTTP_AUTHENTICATE_SCHEME_NEGOTIATE);
+        $this->assertSame('OAuth', HeaderWWWAuthenticate::HTTP_AUTHENTICATE_SCHEME_OAUTH);
+        $this->assertSame('SCRAM-SHA-1', HeaderWWWAuthenticate::HTTP_AUTHENTICATE_SCHEME_SCRAM_SHA_1);
+        $this->assertSame('SCRAM-SHA-256', HeaderWWWAuthenticate::HTTP_AUTHENTICATE_SCHEME_SCRAM_SHA_256);
+        $this->assertSame('vapid', HeaderWWWAuthenticate::HTTP_AUTHENTICATE_SCHEME_VAPID);
     }
 
     public function testConstructor()
@@ -56,7 +56,7 @@ class HeaderWWWAuthenticateTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setScheme('overwritten-scheme'));
 
-        $this->assertEquals('overwritten-scheme', $header->getScheme());
+        $this->assertSame('overwritten-scheme', $header->getScheme());
     }
 
     public function testSetInvalidScheme()
@@ -77,7 +77,7 @@ class HeaderWWWAuthenticateTest extends TestCase
             $header->setParameter('parameter-name', 'overwritten-parameter-value')
         );
 
-        $this->assertEquals(['parameter-name' => 'overwritten-parameter-value'], $header->getParameters());
+        $this->assertSame(['parameter-name' => 'overwritten-parameter-value'], $header->getParameters());
     }
 
     public function testSetSeveralParameters()
@@ -90,7 +90,7 @@ class HeaderWWWAuthenticateTest extends TestCase
         $header->setParameter('parameter-name-1', 'overwritten-parameter-value-1');
         $header->setParameter('parameter-name-2', 'overwritten-parameter-value-2');
 
-        $this->assertEquals([
+        $this->assertSame([
             'parameter-name-1' => 'overwritten-parameter-value-1',
             'parameter-name-2' => 'overwritten-parameter-value-2',
         ], $header->getParameters());
@@ -126,7 +126,7 @@ class HeaderWWWAuthenticateTest extends TestCase
             'parameter-name-2' => 'overwritten-parameter-value-2',
         ]));
 
-        $this->assertEquals([
+        $this->assertSame([
             'parameter-name-1' => 'overwritten-parameter-value-1',
             'parameter-name-2' => 'overwritten-parameter-value-2',
         ], $header->getParameters());
@@ -154,14 +154,14 @@ class HeaderWWWAuthenticateTest extends TestCase
     {
         $header = new HeaderWWWAuthenticate('scheme');
 
-        $this->assertEquals('scheme', $header->getScheme());
+        $this->assertSame('scheme', $header->getScheme());
     }
 
     public function testGetParameters()
     {
         $header = new HeaderWWWAuthenticate('scheme', ['parameter-name' => 'parameter-value']);
 
-        $this->assertEquals(['parameter-name' => 'parameter-value'], $header->getParameters());
+        $this->assertSame(['parameter-name' => 'parameter-value'], $header->getParameters());
     }
 
     public function testClearParameters()
@@ -178,42 +178,42 @@ class HeaderWWWAuthenticateTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->clearParameters());
 
-        $this->assertEquals([], $header->getParameters());
+        $this->assertSame([], $header->getParameters());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderWWWAuthenticate('scheme');
 
-        $this->assertEquals('WWW-Authenticate', $header->getFieldName());
+        $this->assertSame('WWW-Authenticate', $header->getFieldName());
     }
 
     public function testGetFieldValue()
     {
         $header = new HeaderWWWAuthenticate('scheme', ['parameter-name' => 'parameter-value']);
 
-        $this->assertEquals('scheme parameter-name="parameter-value"', $header->getFieldValue());
+        $this->assertSame('scheme parameter-name="parameter-value"', $header->getFieldValue());
     }
 
     public function testToStringWithoutParameters()
     {
         $header = new HeaderWWWAuthenticate('scheme');
 
-        $this->assertEquals('WWW-Authenticate: scheme', (string) $header);
+        $this->assertSame('WWW-Authenticate: scheme', (string) $header);
     }
 
     public function testToStringWithParameterWithoutValue()
     {
         $header = new HeaderWWWAuthenticate('scheme', ['parameter-name' => '']);
 
-        $this->assertEquals('WWW-Authenticate: scheme parameter-name=""', (string) $header);
+        $this->assertSame('WWW-Authenticate: scheme parameter-name=""', (string) $header);
     }
 
     public function testToStringWithOneParameter()
     {
         $header = new HeaderWWWAuthenticate('scheme', ['parameter-name' => 'parameter-value']);
 
-        $this->assertEquals('WWW-Authenticate: scheme parameter-name="parameter-value"', (string) $header);
+        $this->assertSame('WWW-Authenticate: scheme parameter-name="parameter-value"', (string) $header);
     }
 
     public function testToStringWithSeveralParameters()
@@ -227,6 +227,6 @@ class HeaderWWWAuthenticateTest extends TestCase
         $expected = 'WWW-Authenticate: scheme parameter-name-1="parameter-value-1", ' .
                     'parameter-name-2="parameter-value-2", parameter-name-3="parameter-value-3"';
 
-        $this->assertEquals($expected, (string) $header);
+        $this->assertSame($expected, (string) $header);
     }
 }

--- a/tests/HeaderWarningTest.php
+++ b/tests/HeaderWarningTest.php
@@ -10,13 +10,13 @@ class HeaderWarningTest extends TestCase
 {
     public function testConstants()
     {
-        $this->assertEquals(110, HeaderWarning::HTTP_WARNING_CODE_RESPONSE_IS_STALE);
-        $this->assertEquals(111, HeaderWarning::HTTP_WARNING_CODE_REVALIDATION_FAILED);
-        $this->assertEquals(112, HeaderWarning::HTTP_WARNING_CODE_DISCONNECTED_OPERATION);
-        $this->assertEquals(113, HeaderWarning::HTTP_WARNING_CODE_HEURISTIC_EXPIRATION);
-        $this->assertEquals(199, HeaderWarning::HTTP_WARNING_CODE_MISCELLANEOUS_WARNING);
-        $this->assertEquals(214, HeaderWarning::HTTP_WARNING_CODE_TRANSFORMATION_APPLIED);
-        $this->assertEquals(299, HeaderWarning::HTTP_WARNING_CODE_MISCELLANEOUS_PERSISTENT_WARNING);
+        $this->assertSame(110, HeaderWarning::HTTP_WARNING_CODE_RESPONSE_IS_STALE);
+        $this->assertSame(111, HeaderWarning::HTTP_WARNING_CODE_REVALIDATION_FAILED);
+        $this->assertSame(112, HeaderWarning::HTTP_WARNING_CODE_DISCONNECTED_OPERATION);
+        $this->assertSame(113, HeaderWarning::HTTP_WARNING_CODE_HEURISTIC_EXPIRATION);
+        $this->assertSame(199, HeaderWarning::HTTP_WARNING_CODE_MISCELLANEOUS_WARNING);
+        $this->assertSame(214, HeaderWarning::HTTP_WARNING_CODE_TRANSFORMATION_APPLIED);
+        $this->assertSame(299, HeaderWarning::HTTP_WARNING_CODE_MISCELLANEOUS_PERSISTENT_WARNING);
     }
 
     public function testConstructorWithoutDate()
@@ -65,7 +65,7 @@ class HeaderWarningTest extends TestCase
     {
         $header = new HeaderWarning(199, 'agent', 'text', null);
 
-        $this->assertEquals(null, $header->getDate());
+        $this->assertNull($header->getDate());
     }
 
     public function testSetCode()
@@ -74,7 +74,7 @@ class HeaderWarningTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setCode(299));
 
-        $this->assertEquals(299, $header->getCode());
+        $this->assertSame(299, $header->getCode());
     }
 
     public function testSetSmallCode()
@@ -101,7 +101,7 @@ class HeaderWarningTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setAgent('new-agent'));
 
-        $this->assertEquals('new-agent', $header->getAgent());
+        $this->assertSame('new-agent', $header->getAgent());
     }
 
     public function testSetInvalidAgent()
@@ -119,7 +119,7 @@ class HeaderWarningTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setText('new-text'));
 
-        $this->assertEquals('new-text', $header->getText());
+        $this->assertSame('new-text', $header->getText());
     }
 
     public function testSetInvalidText()
@@ -141,7 +141,7 @@ class HeaderWarningTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setDate($later));
 
-        $this->assertEquals($later, $header->getDate());
+        $this->assertSame($later, $header->getDate());
     }
 
     public function testSetEmptyDate()
@@ -152,28 +152,28 @@ class HeaderWarningTest extends TestCase
 
         $this->assertInstanceOf(HeaderInterface::class, $header->setDate(null));
 
-        $this->assertEquals(null, $header->getDate());
+        $this->assertNull($header->getDate());
     }
 
     public function testGetCode()
     {
         $header = new HeaderWarning(199, 'agent', 'text');
 
-        $this->assertEquals(199, $header->getCode());
+        $this->assertSame(199, $header->getCode());
     }
 
     public function testGetAgent()
     {
         $header = new HeaderWarning(199, 'agent', 'text');
 
-        $this->assertEquals('agent', $header->getAgent());
+        $this->assertSame('agent', $header->getAgent());
     }
 
     public function testGetText()
     {
         $header = new HeaderWarning(199, 'agent', 'text');
 
-        $this->assertEquals('text', $header->getText());
+        $this->assertSame('text', $header->getText());
     }
 
     public function testGetDate()
@@ -182,21 +182,21 @@ class HeaderWarningTest extends TestCase
 
         $header = new HeaderWarning(199, 'agent', 'text', $now);
 
-        $this->assertEquals($now, $header->getDate());
+        $this->assertSame($now, $header->getDate());
     }
 
     public function testGetFieldName()
     {
         $header = new HeaderWarning(199, 'agent', 'text');
 
-        $this->assertEquals('Warning', $header->getFieldName());
+        $this->assertSame('Warning', $header->getFieldName());
     }
 
     public function testGetFieldValueWithoutDate()
     {
         $header = new HeaderWarning(199, 'agent', 'text');
 
-        $this->assertEquals('199 agent "text"', $header->getFieldValue());
+        $this->assertSame('199 agent "text"', $header->getFieldValue());
     }
 
     public function testGetFieldValueWithDate()
@@ -205,7 +205,7 @@ class HeaderWarningTest extends TestCase
 
         $header = new HeaderWarning(199, 'agent', 'text', new \DateTime('now', new \DateTimeZone('Europe/Moscow')));
 
-        $this->assertEquals(
+        $this->assertSame(
             \sprintf('199 agent "text" "%s"', $utc->format(\DateTime::RFC822)),
             $header->getFieldValue()
         );
@@ -215,7 +215,7 @@ class HeaderWarningTest extends TestCase
     {
         $header = new HeaderWarning(199, 'agent', 'text');
 
-        $this->assertEquals('Warning: 199 agent "text"', (string) $header);
+        $this->assertSame('Warning: 199 agent "text"', (string) $header);
     }
 
     public function testToStringWithDate()
@@ -224,7 +224,7 @@ class HeaderWarningTest extends TestCase
 
         $header = new HeaderWarning(199, 'agent', 'text', new \DateTime('now', new \DateTimeZone('Europe/Moscow')));
 
-        $this->assertEquals(
+        $this->assertSame(
             \sprintf('Warning: 199 agent "text" "%s"', $utc->format(\DateTime::RFC822)),
             (string) $header
         );


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to make assertion equals strict.
- Using the `assertTrue` to assert expected is `true`.
- Using the `assertFalse` to assert expected is `false`.
- Using the `assertNull` to assert expected is `null`.