### PR TITLE
Change into PHP7.4 for mini and make equals strict

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## HTTP header kit for PHP 7.1+ compatible with PSR-7, Symfony and Laravel
+## HTTP header kit for PHP 7.4+ compatible with PSR-7, Symfony and Laravel
 
 [![Build Status](https://scrutinizer-ci.com/g/sunrise-php/http-header-kit/badges/build.png?b=master)](https://scrutinizer-ci.com/g/sunrise-php/http-header-kit/build-status/master)
 [![Code Coverage](https://scrutinizer-ci.com/g/sunrise-php/http-header-kit/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/sunrise-php/http-header-kit/?branch=master)

--- a/tests/HeaderAccessControlMaxAgeTest.php
+++ b/tests/HeaderAccessControlMaxAgeTest.php
@@ -36,7 +36,7 @@ class HeaderAccessControlMaxAgeTest extends TestCase
     {
         $header = new HeaderAccessControlMaxAge($validValue);
 
-        $this->assertEquals($validValue, $header->getFieldValue());
+        $this->assertSame((string) $validValue, $header->getFieldValue());
     }
 
     public function validValueDataProvider() : array

--- a/tests/HeaderAgeTest.php
+++ b/tests/HeaderAgeTest.php
@@ -36,7 +36,7 @@ class HeaderAgeTest extends TestCase
     {
         $header = new HeaderAge($validValue);
 
-        $this->assertEquals($validValue, $header->getFieldValue());
+        $this->assertSame((string) $validValue, $header->getFieldValue());
     }
 
     public function validValueDataProvider() : array

--- a/tests/HeaderCustomTest.php
+++ b/tests/HeaderCustomTest.php
@@ -19,14 +19,14 @@ class HeaderCustomTest extends TestCase
     {
         $header = new HeaderCustom('foo', 'bar');
 
-        $this->assertEquals('foo', $header->getFieldName());
+        $this->assertSame('foo', $header->getFieldName());
     }
 
     public function testFieldValue()
     {
         $header = new HeaderCustom('foo', 'bar');
 
-        $this->assertEquals('bar', $header->getFieldValue());
+        $this->assertSame('bar', $header->getFieldValue());
     }
 
     public function testInvalidFieldName()
@@ -49,7 +49,7 @@ class HeaderCustomTest extends TestCase
     {
         $header = new HeaderCustom('foo', '');
 
-        $this->assertEquals('', $header->getFieldValue());
+        $this->assertSame('', $header->getFieldValue());
     }
 
     public function testInvalidFieldValue()


### PR DESCRIPTION
# Changed log

- According to the `composer.json` file, it seems that the minimum PHP version is `7.4` in the repository. And it should change the correct title in the `README.md`.
- Using the `assertSame` to make assert equals strict.